### PR TITLE
Improvements to ndlstm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ The library currently provides:
 # Other Dimensions
 
 There is 1D LSTM code in `lstm1d.py`. This code implements 1D LSTM versions
-suitable as a basis for higher dimensional LSTMs. It is intended for constant
-batch size and uses a different layout.  Although the code is perfectly fine for
+suitable as a basis for higher dimensional LSTMs. Although the code is perfectly fine for
 1D use, you may find other 1D LSTM implementations to be more convenient if you
 are interested in sequence problems.
 

--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,7 @@ from __future__ import division
 from __future__ import print_function
 
 # pylint: disable=wildcard-import,g-importing-member
-from tfndlstm.lstm1d import *
-from tfndlstm.lstm2d import *
-from tfndlstm.misc import *
+from lstm1d import *
+from lstm2d import *
+from misc import *
 # pylint: enable=wildcard-import

--- a/lstm1d.py
+++ b/lstm1d.py
@@ -91,14 +91,14 @@ def ndlstm_base_dynamic(inputs, noutput, scope=None, reverse=False):
     sequence_length = int(inputs.get_shape()[0])
     sequence_lengths = tf.to_int64(tf.fill([batch_size], sequence_length))
     if reverse:
-      inputs = tf.reverse(inputs, [True, False, False])
+      inputs = tf.reverse_v2(inputs, [0])
     outputs, _ = tf.nn.dynamic_rnn(lstm_cell,
                                    inputs,
                                    sequence_lengths,
                                    state,
                                    time_major=True)
     if reverse:
-      outputs = tf.reverse(outputs, [True, False, False])
+      outputs = tf.reverse_v2(outputs, [0])
     return outputs
 
 

--- a/lstm1d_test.py
+++ b/lstm1d_test.py
@@ -20,7 +20,8 @@ from __future__ import print_function
 
 import numpy as np
 import tensorflow as tf
-lstm1d = tf.contrib.ndlstm.lstm1d
+
+import lstm1d
 
 
 def _rand(*size):

--- a/lstm1d_test.py
+++ b/lstm1d_test.py
@@ -47,20 +47,13 @@ class Lstm1DTest(tf.test.TestCase):
       inputs = tf.constant(_rand(*size))
       outputs = lstm1d.ndlstm_base(inputs, 8, dynamic=False)
       tf.global_variables_initializer().run()
-      gradients = tf.gradients(outputs, inputs)
-      if 1:  # pylint: disable=using-constant-test
-        gradients = tf.gradients(outputs, inputs)[0].eval()
-        self.assertEqual(gradients.shape, size)
-      else:
-        # TODO(tmb) tf.test.compute_gradient error is currently broken
-        # with dynamic_rnn. Enable this test case eventually.
-        err = tf.test.compute_gradient_error(inputs,
-                                             size,
-                                             outputs,
-                                             output_size,
-                                             delta=1e-4)
-        self.assert_(not np.isnan(err))
-        self.assert_(err < 0.1)
+      err = tf.test.compute_gradient_error(inputs,
+                                           size,
+                                           outputs,
+                                           output_size,
+                                           delta=1e-4)
+      self.assert_(not np.isnan(err))
+      self.assert_(err < 0.1)
 
   def testSequenceToSequenceGradientReverse(self):
     with self.test_session():
@@ -69,19 +62,13 @@ class Lstm1DTest(tf.test.TestCase):
       inputs = tf.constant(_rand(*size))
       outputs = lstm1d.ndlstm_base(inputs, 8, reverse=1, dynamic=False)
       tf.global_variables_initializer().run()
-      if 1:  # pylint: disable=using-constant-test
-        gradients = tf.gradients(outputs, inputs)[0].eval()
-        self.assertEqual(gradients.shape, size)
-      else:
-        # TODO(tmb) tf.test.compute_gradient error is currently broken
-        # with dynamic_rnn. Enable this test case eventually.
-        err = tf.test.compute_gradient_error(inputs,
-                                             size,
-                                             outputs,
-                                             output_size,
-                                             delta=1e-4)
-        self.assert_(not np.isnan(err))
-        self.assert_(err < 0.1)
+      err = tf.test.compute_gradient_error(inputs,
+                                           size,
+                                           outputs,
+                                           output_size,
+                                           delta=1e-4)
+      self.assert_(not np.isnan(err))
+      self.assert_(err < 0.1)
 
   def testSequenceToFinalDims(self):
     with self.test_session():

--- a/lstm2d_test.py
+++ b/lstm2d_test.py
@@ -79,6 +79,32 @@ class Lstm2DTest(test_util.TensorFlowTestCase):
       result = outputs.eval()
       self.assertEqual(tuple(result.shape), (2, 8, 7, 11))
 
+  def testSeparableLstmUnsupportedCellType(self):
+    with self.test_session():
+      inputs = tf.constant(_rand(2, 5, 7, 11))
+      cell_type = "unsupported cell type"
+      with self.assertRaisesRegexp(NotImplementedError,
+                                   cell_type + " not supported by ndlstm."):
+        lstm2d.separable_lstm(inputs, 8, data_format='NCHW', cell_type=cell_type)
+
+  def testSeparableGLstmDims(self):
+    with self.test_session():
+      inputs = tf.constant(_rand(2, 5, 7, 11))
+      outputs = lstm2d.separable_lstm(inputs, 8, data_format='NCHW',
+                                      cell_type='GLSTM')
+      tf.global_variables_initializer().run()
+      result = outputs.eval()
+      self.assertEqual(tuple(result.shape), (2, 8, 7, 11))
+
+  def testSeparableGruDims(self):
+    with self.test_session():
+      inputs = tf.constant(_rand(2, 5, 7, 11))
+      outputs = lstm2d.separable_lstm(inputs, 8, data_format='NCHW',
+                                      cell_type='GRU')
+      tf.global_variables_initializer().run()
+      result = outputs.eval()
+      self.assertEqual(tuple(result.shape), (2, 8, 7, 11))
+
   def testReduceToSequenceDims(self):
     with self.test_session():
       inputs = tf.constant(_rand(2, 7, 11, 5))

--- a/lstm2d_test.py
+++ b/lstm2d_test.py
@@ -56,6 +56,13 @@ class Lstm2DTest(test_util.TensorFlowTestCase):
       result = outputs.eval()
       self.assertEqual(tuple(result.shape), size)
 
+  def testSeparableLstmDimsInvalidDataFormat(self):
+    with self.test_session():
+      inputs = tf.constant(_rand(2, 7, 11, 5))
+      with self.assertRaisesRegexp(ValueError,
+                                   'data_format has to be either NCHW or NHWC.'):
+        lstm2d.separable_lstm(inputs, 8, data_format="CHWN")
+
   def testSeparableLstmDims(self):
     with self.test_session():
       inputs = tf.constant(_rand(2, 7, 11, 5))
@@ -63,6 +70,14 @@ class Lstm2DTest(test_util.TensorFlowTestCase):
       tf.global_variables_initializer().run()
       result = outputs.eval()
       self.assertEqual(tuple(result.shape), (2, 7, 11, 8))
+
+  def testSeparableLstmDimsNCHW(self):
+    with self.test_session():
+      inputs = tf.constant(_rand(2, 5, 7, 11))
+      outputs = lstm2d.separable_lstm(inputs, 8, data_format='NCHW')
+      tf.global_variables_initializer().run()
+      result = outputs.eval()
+      self.assertEqual(tuple(result.shape), (2, 8, 7, 11))
 
   def testReduceToSequenceDims(self):
     with self.test_session():

--- a/lstm2d_test.py
+++ b/lstm2d_test.py
@@ -20,8 +20,8 @@ from __future__ import print_function
 
 import numpy as np
 import tensorflow as tf
+import lstm2d
 from tensorflow.python.framework import test_util
-lstm2d = tf.contrib.ndlstm.lstm2d
 
 
 def _rand(*size):
@@ -41,7 +41,7 @@ class Lstm2DTest(test_util.TensorFlowTestCase):
   def testSequenceToImagesDims(self):
     with self.test_session():
       inputs = tf.constant(_rand(11, 14, 5))
-      outputs = lstm2d.sequence_to_images(inputs, 2)
+      outputs = lstm2d.sequence_to_images(inputs, 7)
       tf.global_variables_initializer().run()
       result = outputs.eval()
       self.assertEqual(tuple(result.shape), (2, 7, 11, 5))
@@ -51,7 +51,7 @@ class Lstm2DTest(test_util.TensorFlowTestCase):
       size = (2, 7, 11, 5)
       inputs = tf.constant(_rand(*size))
       sequence = lstm2d.images_to_sequence(inputs)
-      outputs = lstm2d.sequence_to_images(sequence, size[0])
+      outputs = lstm2d.sequence_to_images(sequence, size[1])
       tf.global_variables_initializer().run()
       result = outputs.eval()
       self.assertEqual(tuple(result.shape), size)

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,22 @@
 """Multidimensional LSTMs for TensorFlow.
 """
 
-from setuptools import setup, find_packages
+from setuptools import setup
 from codecs import open
 from os import path
-here  =  path.abspath(path.dirname(__file__))
+here = path.abspath(path.dirname(__file__))
 
-with open(path.join(here, "README.md"), encoding = "utf-8") as stream:
-    long_description  =  stream.read()
+with open(path.join(here, "README.md"), encoding="utf-8") as stream:
+    long_description = stream.read()
 
 setup(
-    name = "tfndlstm",
-    version = "0.0.2",
-    description = "Multidimensional LSTMs for TensorFlow",
-    long_description = long_description,
-    # url = "https://github.com/pypa/sampleproject",
-    author = "Thomas Breuel",
-    author_email = "tbreuel@nvidia.com",
-    license = "MIT",
+    name="tfndlstm",
+    version="0.0.2",
+    description="Multidimensional LSTMs for TensorFlow",
+    long_description=long_description,
+    author="Thomas Breuel",
+    author_email="tbreuel@nvidia.com",
+    license="MIT",
     package_dir={"tfndlstm": "."},
-    packages = ["tfndlstm"],
+    packages=["tfndlstm"], install_requires=['numpy', 'tensorflow']
 )


### PR DESCRIPTION
-Separable LSTM Supports dynamic batch size.
-Uses bidirectional rnns in horizontal lstms.
-Added channels first support for separable lstms.
-Different types of cells can be used for separable lstms.
-lstm1d sequence-softmax uses slim.fully_connected.
-Enabled used to be broken tests in lstm1d.
-Updated readme and requirements.